### PR TITLE
Secrets can now be mounted on a custom path

### DIFF
--- a/src/OperatorAnnotations.cs
+++ b/src/OperatorAnnotations.cs
@@ -11,6 +11,11 @@ internal static class OperatorAnnotations
     public const string CronTimezone = "justfaas.com/cron-timezone";
 
     /// <summary>
+    /// The mount path for the function's secrets.
+    /// </summary>
+    public static readonly ( string Key, string Default ) SecretsMountPath = ( "justfaas.com/secrets-mount-path", "/var/faas/secrets" );
+
+    /// <summary>
     /// Indicates the namespace of the gateway that operates the function. This is an internal runtime-only annotation.
     /// </summary>
     internal static readonly ( string Key, string Default ) GatewayNamespace = ( "justfaas.com/gateway-namespace", "faas" );

--- a/src/V1Alpha1/Functions/Builders/DeploymentBuilder.cs
+++ b/src/V1Alpha1/Functions/Builders/DeploymentBuilder.cs
@@ -9,6 +9,7 @@ public sealed class V1Alpha1DeploymentBuilder
     {
         var volumes = new List<V1Volume>();
         var volumeMounts = new List<V1VolumeMount>();
+        var secretMountPath = func.GetAnnotationValue( OperatorAnnotations.SecretsMountPath );
 
         if ( func.Spec.Secrets?.Any() == true )
         {
@@ -19,7 +20,7 @@ public sealed class V1Alpha1DeploymentBuilder
                 var volumeMount = new V1VolumeMount
                 {
                     Name = volumeName,
-                    MountPath = "/var/faas/secrets",
+                    MountPath = secretMountPath,
                     ReadOnlyProperty = true
                 };
 

--- a/tests/DeploymentBuilder.cs
+++ b/tests/DeploymentBuilder.cs
@@ -1,0 +1,55 @@
+using Faactory.k8s.Models;
+using Faactory.k8s.Models.Builders;
+using k8s.Models;
+
+namespace tests;
+
+public class DeploymentBuilderTests
+{
+    [Fact]
+    public void TestSecretsMountPath()
+    {
+        var function = new V1Alpha1Function
+        {
+            Metadata = new V1ObjectMeta
+            {
+                Name = "hello",
+                NamespaceProperty = "test"
+            },
+            Spec = new V1Alpha1Function.FunctionSpec
+            {
+                Image = "gcr.io/google-samples/hello-app:1.0",
+                Secrets = new string[]
+                {
+                    "secret1",
+                    "secret2"
+                }
+            }
+        };
+
+        var deployment = new V1Alpha1DeploymentBuilder().Build( function, "test" );
+
+        Assert.Single( deployment.Spec.Template.Spec.Containers );
+        Assert.Equal( 2, deployment.Spec.Template.Spec.Containers.Single().VolumeMounts.Count );
+        Assert.Equal( "secret1-secret-vol", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name );
+        Assert.Equal( "secret2-secret-vol", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name );
+        Assert.Equal( "/var/faas/secrets", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath );
+        Assert.Equal( "/var/faas/secrets", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath );
+
+        // annotate custom secrets mount path
+        function.Metadata.Annotations = new Dictionary<string, string>
+        {
+            { OperatorAnnotations.SecretsMountPath.Key, "/app/secrets" }
+        };
+
+        // rebuild deployment
+        deployment = new V1Alpha1DeploymentBuilder().Build( function, "test" );
+
+        Assert.Single( deployment.Spec.Template.Spec.Containers );
+        Assert.Equal( 2, deployment.Spec.Template.Spec.Containers.Single().VolumeMounts.Count );
+        Assert.Equal( "secret1-secret-vol", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name );
+        Assert.Equal( "secret2-secret-vol", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name );
+        Assert.Equal( "/app/secrets", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath );
+        Assert.Equal( "/app/secrets", deployment.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath );
+    }
+}


### PR DESCRIPTION
By providing an annotation, it's now possible to customize the path where secrets are mapped to in the function's container. The default behaviour does not change.

```yaml
apiVersion: justfaas.com/v1alpha1
kind: Function
metadata:
  name: hello
  namespace: default
  annotations:
    justfaas.com/secrets-mount-path: /app/secrets
spec:
  image: gcr.io/google-samples/hello-app:1.0
  secrets:
    - my-secret
```

The above will mount the function's secrets at `/app/secrets` as annotated.